### PR TITLE
Release date share bug (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## v0.1.1 - April 10, 2025
+
+### Bug Fixes
+
+- Fixed an issue where the emoji in shared game results incorrectly displayed the release date status

--- a/app/components/classic/FeedbackRow.vue
+++ b/app/components/classic/FeedbackRow.vue
@@ -7,10 +7,6 @@ defineProps<{
   correctWarframe: Warframe;
 }>();
 
-const parseReleaseDate = (releaseDate: string) => {
-  return Number(releaseDate.split("-")[0]);
-};
-
 const compareNumeric = (guessed: number, correct: number) => {
   if (guessed === correct) return { isCorrect: true };
   return {

--- a/app/composables/useShare.ts
+++ b/app/composables/useShare.ts
@@ -60,11 +60,11 @@ export function useShare() {
     } else {
       gridRow.push(emojis.correct);
     }
-    if (correctItem.releaseDate !== guessedItem.releaseDate) {
+    const correctReleaseDate = parseReleaseDate(correctItem.releaseDate);
+    const guessedReleaseDate = parseReleaseDate(guessedItem.releaseDate);
+    if (correctReleaseDate !== guessedReleaseDate) {
       gridRow.push(
-        correctItem.releaseDate > guessedItem.releaseDate
-          ? emojis.higher
-          : emojis.lower,
+        correctReleaseDate > guessedReleaseDate ? emojis.higher : emojis.lower,
       );
     } else {
       gridRow.push(emojis.correct);

--- a/app/utils/date.ts
+++ b/app/utils/date.ts
@@ -1,0 +1,3 @@
+export const parseReleaseDate = (releaseDate: string) => {
+  return Number(releaseDate.split("-")[0]);
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "framedle",
   "private": true,
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "scripts": {
     "build": "NODE_OPTIONS=--max_old_space_size=8192 nuxt build",
     "dev": "nuxt dev",


### PR DESCRIPTION
* turned parseReleaseDate into a util function that can be used across the app

* changed release dates in share calculations to compare years instead of full date

* updated changelog

* updated version

* added date to changelog